### PR TITLE
Added per-body epoch to reference mean anomalies

### DIFF
--- a/data/jnsq/bodies.yml
+++ b/data/jnsq/bodies.yml
@@ -12,7 +12,8 @@
 # inclination:        ° (degrees)
 # argOfPeriapsis:     °
 # ascNodeLongitude:   °
-# meanAnomaly:        rad, at 0s UT
+# meanAnomaly0:       rad, mean anomaly at UT = epoch
+# epoch:              s
 # sideralPeriod:      s
 
 
@@ -59,6 +60,7 @@
     ascNodeLongitude: 70
     sideralPeriod:    3_796_156.8
   meanAnomaly0:       0
+  epoch:              0
   orbiting:           0
   color:              0xa88161
 
@@ -79,6 +81,7 @@
     ascNodeLongitude: 15
     sideralPeriod:    9_693_648
   meanAnomaly0:       5.7
+  epoch:              0
   orbiting:           0
   color:              0x6c20e4
 
@@ -99,6 +102,7 @@
     ascNodeLongitude: 80
     sideralPeriod:    670_334.4
   meanAnomaly0:       0
+  epoch:              0
   orbiting:           2
   color:              0x6f5248
 
@@ -119,6 +123,7 @@
     ascNodeLongitude: 0
     sideralPeriod:    15_768_000
   meanAnomaly0:       0
+  epoch:              0
   orbiting:           0
   color:              0x8acac2
 
@@ -139,6 +144,7 @@
     ascNodeLongitude: 45
     sideralPeriod:    1_087_862.4
   meanAnomaly0:       0
+  epoch:              0
   orbiting:           4
   color:              0x6b6a76
 
@@ -159,6 +165,7 @@
     ascNodeLongitude: 75
     sideralPeriod:    2_234_304
   meanAnomaly0:       30
+  epoch:              0
   orbiting:           4
   color:              0x5b4c68
 
@@ -179,6 +186,7 @@
     ascNodeLongitude: 135.5
     sideralPeriod:    29_665_872
   meanAnomaly0:       0.9
+  epoch:              0
   orbiting:           0
   color:              0xa23e28
 
@@ -199,6 +207,7 @@
     ascNodeLongitude: 90
     sideralPeriod:    955_497.6
   meanAnomaly0:       180
+  epoch:              0
   orbiting:           7
   color:              0x5d5d5f
 
@@ -219,6 +228,7 @@
     ascNodeLongitude: 30
     sideralPeriod:    62_594_229.6
   meanAnomaly0:       0
+  epoch:              0
   orbiting:           0
   color:              0x8c5926
 
@@ -239,6 +249,7 @@
     ascNodeLongitude: 120
     sideralPeriod:    284_234.4
   meanAnomaly0:       0
+  epoch:              0
   orbiting:           9
   color:              0x808080
 
@@ -259,6 +270,7 @@
     ascNodeLongitude: 280
     sideralPeriod:    82_053_518.4
   meanAnomaly0:       3.9
+  epoch:              0
   orbiting:           0
   color:              0x5a4432
 
@@ -279,6 +291,7 @@
     ascNodeLongitude:	52
     sideralPeriod:    179_313_696
   meanAnomaly0:       0.6
+  epoch:              0
   orbiting:           0
   color:              0x548412
 
@@ -299,6 +312,7 @@
     ascNodeLongitude: 120
     sideralPeriod:    115_300.8
   meanAnomaly0:       180
+  epoch:              0
   orbiting:           12
   color:              0x2c306a
 
@@ -319,6 +333,7 @@
     ascNodeLongitude: 90
     sideralPeriod:    285029.28
   meanAnomaly0:       180
+  epoch:              0
   orbiting:           12
   color:              0x476c7c
 
@@ -339,6 +354,7 @@
     ascNodeLongitude: 150
     sideralPeriod:    704_635.2
   meanAnomaly0:       270
+  epoch:              0
   orbiting:           12
   color:              0x937575
 
@@ -359,6 +375,7 @@
     ascNodeLongitude: 10
     sideralPeriod:    1_978_084.8
   meanAnomaly0:       270
+  epoch:              0
   orbiting:           12
   color:              0x7f6d51
 
@@ -379,6 +396,7 @@
     ascNodeLongitude: 2
     sideralPeriod:    2_825_841.6
   meanAnomaly0:       1.8
+  epoch:              0
   orbiting:           12
   color:              0x9ba078
 
@@ -399,6 +417,7 @@
     ascNodeLongitude:	80
     sideralPeriod:    467_694_648
   meanAnomaly0:       3.3
+  epoch:              0
   orbiting:           0
   color:              0x4d8dcc
 
@@ -419,6 +438,7 @@
     ascNodeLongitude: 60
     sideralPeriod:    116_039.52
   meanAnomaly0:       3.14
+  epoch:              0
   orbiting:           18
   color:              0x2c306a
 
@@ -439,6 +459,7 @@
     ascNodeLongitude: 120
     sideralPeriod:    286_873.92
   meanAnomaly0:       0
+  epoch:              0
   orbiting:           18
   color:              0xb39980
 
@@ -459,6 +480,7 @@
     ascNodeLongitude: 150
     sideralPeriod:    664_156.8
   meanAnomaly0:       90
+  epoch:              0
   orbiting:           18
   color:              0xcc7f33
 
@@ -480,6 +502,7 @@
     meanAnomaly:      0.9
     sideralPeriod:    1_407_672
   meanAnomaly0:       180
+  epoch:              0
   orbiting:           18
   color:              0x7f99b3
 
@@ -500,6 +523,7 @@
     ascNodeLongitude: 180
     sideralPeriod:    3_573_028.8
   meanAnomaly0:       90
+  epoch:              0
   orbiting:           12
   color:              0xb37f99
 
@@ -520,6 +544,7 @@
     ascNodeLongitude: 50
     sideralPeriod:    701_534_088
   meanAnomaly0:       3.54
+  epoch:              0
   orbiting:           0
   color:              0x686a6a
 
@@ -540,6 +565,7 @@
     ascNodeLongitude: 100
     sideralPeriod:    1_548_331.2
   meanAnomaly0:       0
+  epoch:              0
   orbiting:           24
   color:              0xb3997f
 
@@ -560,6 +586,7 @@
     ascNodeLongitude: 105
     sideralPeriod:    4_490_208
   meanAnomaly0:       180
+  epoch:              0
   orbiting:           24
   color:              0x664d33
 
@@ -580,6 +607,7 @@
     ascNodeLongitude: 165
     sideralPeriod:    830_153_664
   meanAnomaly0:       4.7
+  epoch:              0
   orbiting:           0
   color:              0x8c5973
 
@@ -600,6 +628,7 @@
     ascNodeLongitude: 90
     sideralPeriod:    4_858_909_200
   meanAnomaly0:       2.5
+  epoch:              0
   orbiting:           0
   color:              0x4d7f7f
 
@@ -620,6 +649,7 @@
     ascNodeLongitude: 180
     sideralPeriod:    232_809.12
   meanAnomaly0:       180
+  epoch:              0
   orbiting:           28
   color:              0x99b27f
 
@@ -640,6 +670,7 @@
     ascNodeLongitude: 270
     sideralPeriod:    788_097.6
   meanAnomaly0:       180
+  epoch:              0
   orbiting:           28
   color:              0x7f99b2
 
@@ -660,5 +691,6 @@
     ascNodeLongitude: 95
     sideralPeriod:    11_490_768
   meanAnomaly0:       0
+  epoch:              0
   orbiting:           28
   color:              0xb2997f

--- a/data/stock/bodies.yml
+++ b/data/stock/bodies.yml
@@ -13,7 +13,8 @@
 # inclination:        ° (degrees)
 # argOfPeriapsis:     °
 # ascNodeLongitude:   °
-# meanAnomaly:        rad, at 0s UT
+# meanAnomaly0:       rad, mean anomaly at UT = epoch
+# epoch:              s
 # sideralPeriod:      s
 
 
@@ -60,6 +61,7 @@
     ascNodeLongitude: 70
     sideralPeriod:    2_215_754
   meanAnomaly0:       3.14
+  epoch:              0
   orbiting:           0
   color:              0xa88161
 
@@ -80,6 +82,7 @@
     ascNodeLongitude: 15
     sideralPeriod:    5_657_995
   meanAnomaly0:       3.14
+  epoch:              0
   orbiting:           0
   color:              0x6c20e4
   
@@ -100,6 +103,7 @@
     ascNodeLongitude: 80
     sideralPeriod:    388_587
   meanAnomaly0:       0.9
+  epoch:              0
   orbiting:           2
   color:              0x6f5248
 
@@ -120,6 +124,7 @@
     ascNodeLongitude: 0
     sideralPeriod:    9_203_545
   meanAnomaly0:       3.14
+  epoch:              0
   orbiting:           0
   color:              0x8acac2
   
@@ -140,6 +145,7 @@
     ascNodeLongitude: 0
     sideralPeriod:    138_984
   meanAnomaly0:       1.7
+  epoch:              0
   orbiting:           4
   color:              0x6b6a76
   
@@ -160,6 +166,7 @@
     ascNodeLongitude: 78
     sideralPeriod:    1_077_311
   meanAnomaly0:       0.9
+  epoch:              0
   orbiting:           4
   color:              0x5b4c68
 
@@ -180,6 +187,7 @@
     ascNodeLongitude: 135.5
     sideralPeriod:    17_315_400
   meanAnomaly0:       3.14
+  epoch:              0
   orbiting:           0
   color:              0xa23e28
   
@@ -200,6 +208,7 @@
     ascNodeLongitude: 0
     sideralPeriod:    65_518
   meanAnomaly0:       1.7
+  epoch:              0
   orbiting:           7
   color:              0x5d5d5f
   
@@ -220,6 +229,7 @@
     ascNodeLongitude: 280
     sideralPeriod:    47_893_063
   meanAnomaly0:       3.14
+  epoch:              0
   orbiting:           0
   color:              0x5a4432
   
@@ -240,6 +250,7 @@
     ascNodeLongitude:	52
     sideralPeriod:    104_661_432
   meanAnomaly0:       0.1
+  epoch:              0
   orbiting:           0
   color:              0x548412
   
@@ -260,6 +271,7 @@
     ascNodeLongitude: 0
     sideralPeriod:    52_981
   meanAnomaly0:       3.14
+  epoch:              0
   orbiting:           10
   color:              0x2c306a
   
@@ -280,6 +292,7 @@
     ascNodeLongitude: 0
     sideralPeriod:    105_962
   meanAnomaly0:       0.9
+  epoch:              0
   orbiting:           10
   color:              0x476c7c
   
@@ -300,6 +313,7 @@
     ascNodeLongitude: 0
     sideralPeriod:    211_926
   meanAnomaly0:       3.14
+  epoch:              0
   orbiting:           10
   color:              0x937575
   
@@ -321,6 +335,7 @@
     meanAnomaly:      0.9
     sideralPeriod:    544_507
   meanAnomaly0:       0.9
+  epoch:              0
   orbiting:           10
   color:              0x7f6d51
   
@@ -341,6 +356,7 @@
     ascNodeLongitude: 2
     sideralPeriod:    901_903
   meanAnomaly0:       0.9
+  epoch:              0
   orbiting:           10
   color:              0x9ba078
   
@@ -361,5 +377,6 @@
     ascNodeLongitude: 50
     sideralPeriod:    156_992_048
   meanAnomaly0:       3.14
+  epoch:              0
   orbiting:           0
   color:              0x686a6a

--- a/dist/dedicated-workers/libs/physics-3d.js
+++ b/dist/dedicated-workers/libs/physics-3d.js
@@ -33,7 +33,7 @@ var Physics3D;
     Physics3D.equatorialCircularOrbit = equatorialCircularOrbit;
     function bodyStateAtDate(body, orbit, attractor, date) {
         const n = body.orbit.meanMotion;
-        const M = body.meanAnomaly0 + n * date;
+        const M = body.meanAnomaly0 + n * (date - body.epoch);
         const nu = trueAnomalyFromMeanAnomaly(orbit.eccentricity, M);
         return orbitElementsToState(orbit, attractor, nu);
     }

--- a/dist/main/objects/body.js
+++ b/dist/main/objects/body.js
@@ -28,6 +28,7 @@ export class OrbitingBody extends CelestialBody {
         this.attractor = attractor;
         this.orbit = new Orbit(data.orbit, this.attractor, config);
         this.meanAnomaly0 = data.meanAnomaly0;
+        this.epoch = data.epoch;
         this.orbiting = data.orbiting;
         const { stdGravParam } = this.attractor;
         const { semiMajorAxis } = this.orbit;
@@ -37,13 +38,14 @@ export class OrbitingBody extends CelestialBody {
         return {
             ...super.data,
             meanAnomaly0: this.meanAnomaly0,
+            epoch: this.epoch,
             orbiting: this.orbiting,
             circularVel: this.circularVel,
             orbit: this.orbit.data
         };
     }
     trueAnomalyAtDate(date) {
-        return this.orbit.solveTrueAnomalyAtDate(this.meanAnomaly0, date);
+        return this.orbit.solveTrueAnomalyAtDate(this.meanAnomaly0, this.epoch, date);
     }
     positionAtDate(date) {
         const anomaly = this.trueAnomalyAtDate(date);

--- a/dist/main/objects/orbit.js
+++ b/dist/main/objects/orbit.js
@@ -52,9 +52,9 @@ export class Orbit {
         };
         return new Orbit(data, attractor, config, false);
     }
-    solveTrueAnomalyAtDate(meanAnomaly0, date) {
+    solveTrueAnomalyAtDate(meanAnomaly0, epoch, date) {
         const e = this.eccentricity;
-        const deltaTime = date;
+        const deltaTime = date - epoch;
         const M = meanAnomaly0 + this.meanMotion * deltaTime;
         const newton = (f, df) => {
             let n = 0;

--- a/dist/main/solvers/trajectory.js
+++ b/dist/main/solvers/trajectory.js
@@ -304,7 +304,7 @@ export class Trajectory {
         const orbit = this.orbits[i];
         const relDate = date - step.dateOfStart;
         const { startM } = step;
-        const trueAnom = orbit.solveTrueAnomalyAtDate(startM, relDate);
+        const trueAnom = orbit.solveTrueAnomalyAtDate(startM, 0, relDate);
         const pos = orbit.positionFromTrueAnomaly(trueAnom);
         const { scale } = this.config.rendering;
         pod.position.set(pos.x, pos.y, pos.z);

--- a/src/dedicated-workers/libs/physics-3d.ts
+++ b/src/dedicated-workers/libs/physics-3d.ts
@@ -55,7 +55,7 @@ namespace Physics3D
      */
     export function bodyStateAtDate(body: IOrbitingBody, orbit: OrbitalElements3D, attractor: ICelestialBody, date: number) {
         const n = body.orbit.meanMotion as number;
-        const M = body.meanAnomaly0 + n * date;
+        const M = body.meanAnomaly0 + n * (date - body.epoch);
         const nu = trueAnomalyFromMeanAnomaly(orbit.eccentricity, M);
         return orbitElementsToState(orbit, attractor, nu);
     }

--- a/src/main/objects/body.ts
+++ b/src/main/objects/body.ts
@@ -35,6 +35,7 @@ export class CelestialBody implements ICelestialBody {
 
 export class OrbitingBody extends CelestialBody implements IOrbitingBody {
     readonly meanAnomaly0!: number;
+    readonly epoch!:        number;
     readonly orbiting!:     number;
     readonly orbit!:        Orbit;
     readonly circularVel!:  number;
@@ -44,6 +45,7 @@ export class OrbitingBody extends CelestialBody implements IOrbitingBody {
         
         this.orbit        = new Orbit(data.orbit, this.attractor, config);
         this.meanAnomaly0 = data.meanAnomaly0;
+        this.epoch        = data.epoch;
         this.orbiting     = data.orbiting;
         
         // Calculate orbital velocity considering a circular orbit
@@ -56,6 +58,7 @@ export class OrbitingBody extends CelestialBody implements IOrbitingBody {
         return {
             ...super.data,
             meanAnomaly0:   this.meanAnomaly0,
+            epoch:          this.epoch,
             orbiting:       this.orbiting,
             circularVel:    this.circularVel,
             orbit:          this.orbit.data
@@ -67,7 +70,7 @@ export class OrbitingBody extends CelestialBody implements IOrbitingBody {
      * @returns The true anomaly of the body at the specified date.
      */
     public trueAnomalyAtDate(date: number){
-        return this.orbit.solveTrueAnomalyAtDate(this.meanAnomaly0, date);
+        return this.orbit.solveTrueAnomalyAtDate(this.meanAnomaly0, this.epoch, date);
     }
 
     /**

--- a/src/main/objects/orbit.ts
+++ b/src/main/objects/orbit.ts
@@ -77,13 +77,14 @@ export class Orbit implements IOrbit {
     
     /**
      * @param meanAnomaly0 The mean anomaly at some known reference date
+     * @param epoch The epoch at which the meanAnomaly0 corresponds
      * @param date The elapsed time (in seconds) from the reference date at which we want the anomaly
      * @returns The true anomaly of the body on its orbit at the specified date.
      */
-    public solveTrueAnomalyAtDate(meanAnomaly0: number, date: number){
+    public solveTrueAnomalyAtDate(meanAnomaly0: number, epoch: number, date: number){
         const e = this.eccentricity;
         //const deltaTime = this.sideralPeriod ? (date % this.sideralPeriod) : date;
-        const deltaTime = date;
+        const deltaTime = date - epoch;
         const M = meanAnomaly0 + this.meanMotion * deltaTime;
 
         const newton = (

--- a/src/main/solvers/trajectory.ts
+++ b/src/main/solvers/trajectory.ts
@@ -431,7 +431,7 @@ export class Trajectory {
         const orbit = this.orbits[i];
         const relDate = date - step.dateOfStart;
         const {startM} = step;
-        const trueAnom = orbit.solveTrueAnomalyAtDate(startM, relDate);
+        const trueAnom = orbit.solveTrueAnomalyAtDate(startM, 0, relDate);
         const pos = orbit.positionFromTrueAnomaly(trueAnom);
 
         const {scale} = this.config.rendering;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -10,6 +10,7 @@ interface ICelestialBody {
 
 interface IOrbitingBody extends ICelestialBody {
     readonly meanAnomaly0:  number;
+    readonly epoch:         number;
     readonly orbiting:      number;
     readonly orbit:         IOrbit;
     readonly circularVel:   number;


### PR DESCRIPTION
Each (orbiting) body now has a custom `epoch` attribute defining the
date (in seconds) to which `meanAnomaly0` refers to.