### PR TITLE
Trajectory duration limit

### DIFF
--- a/data/jnsq/config.yml
+++ b/data/jnsq/config.yml
@@ -62,6 +62,7 @@ editor:
   defaultOrigin:      3             # default origin body on start (index of Kerbin in the selector)
   defaultDest:        0             # default destination body on start (index of Moho in the selector)
   defaultAltitude:    150           # default altitude from the default body (in km above surface)
+  defaultMaxDuration: 500           # default duration limit for a trajectory (in number of days)
 
 workers:
   progressStep:       250           # number of inputs processed per chunk before progress callback

--- a/data/ko/config.yml
+++ b/data/ko/config.yml
@@ -61,6 +61,7 @@ editor:
   defaultOrigin:      4             # default origin body on start (index of Kerbin in the selector)
   defaultDest:        0             # default destination body on start (index of Moho in the selector)
   defaultAltitude:    100           # default altitude from the default body (in km above surface)
+  defaultMaxDuration: 500           # default duration limit for a trajectory (in number of days)
 
 workers:
   progressStep:       250           # number of inputs processed per chunk before progress callback

--- a/data/opm/config.yml
+++ b/data/opm/config.yml
@@ -61,6 +61,7 @@ editor:
   defaultOrigin:      3             # default origin body on start (index of Kerbin in the selector)
   defaultDest:        0             # default destination body on start (index of Moho in the selector)
   defaultAltitude:    100           # default altitude from the default body (in km above surface)
+  defaultMaxDuration: 500           # default duration limit for a trajectory (in number of days)
 
 workers:
   progressStep:       250           # number of inputs processed per chunk before progress callback

--- a/data/rss/config.yml
+++ b/data/rss/config.yml
@@ -60,6 +60,7 @@ editor:
   defaultOrigin:      2             # default origin body on start (index of Kerbin in the selector)
   defaultDest:        0             # default destination body on start (index of Moho in the selector)
   defaultAltitude:    300           # default altitude from the default body (in km above surface)
+  defaultMaxDuration: 500           # default duration limit for a trajectory (in number of days)
 
 workers:
   progressStep:       250           # number of inputs processed per chunk before progress callback

--- a/data/stock/config.yml
+++ b/data/stock/config.yml
@@ -62,6 +62,7 @@ editor:
   defaultOrigin:      3             # default origin body on start (index of Kerbin in the selector)
   defaultDest:        0             # default destination body on start (index of Moho in the selector)
   defaultAltitude:    100           # default altitude from the default body (in km above surface)
+  defaultMaxDuration: 500           # default duration limit for a trajectory (in number of days)
 
 workers:
   progressStep:       250           # number of inputs processed per chunk before progress callback

--- a/dist/dedicated-workers/libs/trajectory-calculator.js
+++ b/dist/dedicated-workers/libs/trajectory-calculator.js
@@ -110,6 +110,11 @@ class TrajectoryCalculator {
         }
         return total;
     }
+    get totalDuration() {
+        const start = this.steps[0].dateOfStart;
+        const end = this._lastStep.dateOfStart;
+        return end - start;
+    }
     _computeLegDuration(infos) {
         const exitedBody = this.system[infos.exitedBodyId];
         const { durationParam } = infos;

--- a/dist/dedicated-workers/trajectory-optimizer.js
+++ b/dist/dedicated-workers/trajectory-optimizer.js
@@ -45,7 +45,10 @@ class TrajectoryOptimizer extends WorkerEnvironment {
                     const circDV = periVel - Physics3D.circularVelocity(finalBody, periapsis);
                     periVelCost = circDV;
                 }
-                return totDV + totDV * lastInc * 0.1 + periVelCost;
+                const duration = trajectory.totalDuration;
+                const durationOverflow = Math.max(0, duration - this._settings.maxDuration);
+                const durationCost = durationOverflow * totDV;
+                return totDV + totDV * lastInc * 0.1 + periVelCost + durationCost;
             };
             const trajConfig = this._config.trajectorySearch;
             const { diffWeight } = trajConfig;

--- a/dist/main/editor/editor.js
+++ b/dist/main/editor/editor.js
@@ -136,9 +136,6 @@ export async function initEditorWithSystem(systems, systemIndex) {
         const timeRangeEnd = new TimeSelector("end", config);
         timeRangeStart.setToDefault();
         timeRangeEnd.setToDefault();
-        const maxDuration = new IntegerInput("max-duration");
-        maxDuration.setMinMax(1, Infinity);
-        maxDuration.value = config.editor.defaultMaxDuration;
         const depAltitude = new IntegerInput("start-altitude");
         const destAltitude = new IntegerInput("end-altitude");
         const updateAltitudeRange = (input, body) => {
@@ -147,6 +144,15 @@ export async function initEditorWithSystem(systems, systemIndex) {
         };
         depAltitude.value = config.editor.defaultAltitude;
         destAltitude.value = config.editor.defaultAltitude;
+        const maxDuration = new IntegerInput("max-duration");
+        maxDuration.setMinMax(1, Infinity);
+        maxDuration.value = config.editor.defaultMaxDuration;
+        const useMaxDuration = document.getElementById("use-max-duration");
+        const updateUseMaxDuration = () => {
+            maxDuration.element.disabled = !useMaxDuration.checked;
+        };
+        useMaxDuration.onchange = updateUseMaxDuration;
+        updateUseMaxDuration();
         const noInsertionBox = document.getElementById("insertion-checkbox");
         noInsertionBox.checked = false;
         const customSequence = document.getElementById("custom-sequence");
@@ -253,15 +259,18 @@ export async function initEditorWithSystem(systems, systemIndex) {
                 if (!maxDuration.validate()) {
                     throw new Error("Invalid duration limit.");
                 }
-                let maxDurationSeconds;
-                if (config.time.type == "base") {
-                    const { hoursPerDay } = config.time;
-                    const secondsPerDay = hoursPerDay * 3600;
-                    maxDurationSeconds = maxDuration.value * secondsPerDay;
+                let maxDurationSeconds = Infinity;
+                if (useMaxDuration.checked) {
+                    if (config.time.type == "base") {
+                        const { hoursPerDay } = config.time;
+                        const secondsPerDay = hoursPerDay * 3600;
+                        maxDurationSeconds = maxDuration.value * secondsPerDay;
+                    }
+                    else {
+                        maxDurationSeconds = maxDuration.value * 24 * 3600;
+                    }
                 }
-                else {
-                    maxDurationSeconds = maxDuration.value * 24 * 3600;
-                }
+                console.log(maxDurationSeconds);
                 resetFoundTrajectory();
                 const userSettings = {
                     startDate: startDate,

--- a/index.html
+++ b/index.html
@@ -181,6 +181,7 @@
                         <div class="controls">
                             <input class="number-input" name="max-duration" id="max-duration" type="number" value="0" min="1">
                             days
+                            <input name="use-max-duration" id="use-max-duration" type="checkbox">
                         </div>
                     </div>
                     <div id="insertion-checkbox-container">

--- a/index.html
+++ b/index.html
@@ -429,6 +429,15 @@
                             <strong>Departure and destination altitude:</strong> the altitude of the parking orbit
                             around the departure and destination body.
                         </li>
+                        <li>
+                            <strong>Max duration:</strong> if checked, forces the trajectory solver to try not to exceed the
+                            specified maximum duration (in number of days). Note that it may give a trajectory that exceeds the
+                            limit if it cannot find shorter ones.
+                        </li>
+                        <li>
+                            <strong>No insertion burn:</strong> if checked, ignores circularization at the destination body and
+                            instead do a flyby at arrival.
+                        </li>
                     </ul>
                     <p>
                         The trajectory search step will then <em>try</em> to find <em>a possible</em> optimal trajectory given the sequence and the

--- a/index.html
+++ b/index.html
@@ -176,6 +176,13 @@
                             km (above surface level)
                         </div>
                     </div>
+                    <div class="control-group">
+                        <label class="control-label" for="max-duration">Max duration:</label>
+                        <div class="controls">
+                            <input class="number-input" name="max-duration" id="max-duration" type="number" value="0" min="1">
+                            days
+                        </div>
+                    </div>
                     <div id="insertion-checkbox-container">
                         <div class="controls">
                             <input name="insertion-checkbox" id="insertion-checkbox" type="checkbox">

--- a/src/dedicated-workers/libs/trajectory-calculator.ts
+++ b/src/dedicated-workers/libs/trajectory-calculator.ts
@@ -161,6 +161,15 @@ class TrajectoryCalculator {
     }
 
     /**
+     * Returns the duration of the whole trajectory, in seconds.
+     */
+    public get totalDuration(){
+        const start = this.steps[0].dateOfStart;
+        const end = this._lastStep.dateOfStart;
+        return end - start;
+    }
+
+    /**
      * Completes the provided leg infos by calculating the leg duration from the already given
      * parameters
      * @param infos The leg infos to complete

--- a/src/dedicated-workers/trajectory-optimizer.ts
+++ b/src/dedicated-workers/trajectory-optimizer.ts
@@ -80,10 +80,15 @@ class TrajectoryOptimizer extends WorkerEnvironment {
                     periVelCost = circDV;
                 }
                 
+                // Add a big cost value if the duration exceeds the duration limit.
+                const duration = trajectory.totalDuration;
+                const durationOverflow = Math.max(0, duration - this._settings.maxDuration);
+                const durationCost = durationOverflow*totDV;
+
                 // Attempt to force a minimal inclination of the
                 // circular orbit around the destination body
                 // FIX : doesn't work so well...
-                return totDV + totDV*lastInc*0.1 + periVelCost;
+                return totDV + totDV*lastInc*0.1 + periVelCost + durationCost;
             };
 
             const trajConfig = this._config.trajectorySearch;

--- a/src/main/editor/editor.ts
+++ b/src/main/editor/editor.ts
@@ -180,6 +180,11 @@ export async function initEditorWithSystem(systems: SolarSystemData[], systemInd
         timeRangeStart.setToDefault();
         timeRangeEnd.setToDefault();
 
+        // Max duration input
+        const maxDuration = new IntegerInput("max-duration");
+        maxDuration.setMinMax(1, Infinity);
+        maxDuration.value = config.editor.defaultMaxDuration;
+
         // Numerical inputs
         const depAltitude = new IntegerInput("start-altitude");
         const destAltitude = new IntegerInput("end-altitude");
@@ -320,6 +325,19 @@ export async function initEditorWithSystem(systems: SolarSystemData[], systemInd
 
                 const depAltitudeVal = depAltitude.value * 1000;
                 const destAltitudeVal = destAltitude.value * 1000;
+
+                if(!maxDuration.validate()) {
+                    throw new Error("Invalid duration limit.");
+                }
+
+                let maxDurationSeconds: number;
+                if(config.time.type == "base") {
+                    const {hoursPerDay} = config.time;
+                    const secondsPerDay = hoursPerDay * 3600;
+                    maxDurationSeconds = maxDuration.value * secondsPerDay;
+                } else {
+                    maxDurationSeconds = maxDuration.value * 24*3600;
+                }
                 
                 resetFoundTrajectory();
 
@@ -328,7 +346,8 @@ export async function initEditorWithSystem(systems: SolarSystemData[], systemInd
                     endDate:      endDate,
                     depAltitude:  depAltitudeVal,
                     destAltitude: destAltitudeVal,
-                    noInsertion:  noInsertionBox.checked
+                    noInsertion:  noInsertionBox.checked,
+                    maxDuration:  maxDurationSeconds
                 };
 
                 const perfStart = performance.now();

--- a/src/main/editor/editor.ts
+++ b/src/main/editor/editor.ts
@@ -180,11 +180,6 @@ export async function initEditorWithSystem(systems: SolarSystemData[], systemInd
         timeRangeStart.setToDefault();
         timeRangeEnd.setToDefault();
 
-        // Max duration input
-        const maxDuration = new IntegerInput("max-duration");
-        maxDuration.setMinMax(1, Infinity);
-        maxDuration.value = config.editor.defaultMaxDuration;
-
         // Numerical inputs
         const depAltitude = new IntegerInput("start-altitude");
         const destAltitude = new IntegerInput("end-altitude");
@@ -196,6 +191,18 @@ export async function initEditorWithSystem(systems: SolarSystemData[], systemInd
 
         depAltitude.value = config.editor.defaultAltitude;
         destAltitude.value = config.editor.defaultAltitude;
+
+        // Max duration input
+        const maxDuration = new IntegerInput("max-duration");
+        maxDuration.setMinMax(1, Infinity);
+        maxDuration.value = config.editor.defaultMaxDuration;
+
+        const useMaxDuration = document.getElementById("use-max-duration") as HTMLInputElement;
+        const updateUseMaxDuration = () => {
+            maxDuration.element.disabled = !useMaxDuration.checked;
+        };
+        useMaxDuration.onchange = updateUseMaxDuration;
+        updateUseMaxDuration();
 
         // No insertion burn checkbox
         const noInsertionBox = document.getElementById("insertion-checkbox") as HTMLInputElement;
@@ -330,14 +337,17 @@ export async function initEditorWithSystem(systems: SolarSystemData[], systemInd
                     throw new Error("Invalid duration limit.");
                 }
 
-                let maxDurationSeconds: number;
-                if(config.time.type == "base") {
-                    const {hoursPerDay} = config.time;
-                    const secondsPerDay = hoursPerDay * 3600;
-                    maxDurationSeconds = maxDuration.value * secondsPerDay;
-                } else {
-                    maxDurationSeconds = maxDuration.value * 24*3600;
+                let maxDurationSeconds = Infinity;
+                if(useMaxDuration.checked){
+                    if(config.time.type == "base") {
+                        const {hoursPerDay} = config.time;
+                        const secondsPerDay = hoursPerDay * 3600;
+                        maxDurationSeconds = maxDuration.value * secondsPerDay;
+                    } else {
+                        maxDurationSeconds = maxDuration.value * 24*3600;
+                    }
                 }
+                console.log(maxDurationSeconds);
                 
                 resetFoundTrajectory();
 

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -92,6 +92,7 @@ interface EditorSettings {
     readonly defaultOrigin:     number;
     readonly defaultDest:       number;
     readonly defaultAltitude:   number;
+    readonly defaultMaxDuration: number;
 }
 
 interface WorkersSettings {
@@ -317,7 +318,8 @@ type TrajectoryUserSettings = {
     endDate:      number,
     depAltitude:  number,
     destAltitude: number,
-    noInsertion:  boolean
+    noInsertion:  boolean,
+    maxDuration: number
 };
 
 type ResultPannelItems = {


### PR DESCRIPTION
Added a setting in the editor to enforce a trajectory duration limit. Note that this is a soft limit and will not be enforced if the tool cannot find a trajectory that stays in the time limit.

Closes #35