### PR TITLE
Add MPE/OPM config

### DIFF
--- a/data/mpe-opm/bodies.yml
+++ b/data/mpe-opm/bodies.yml
@@ -1,0 +1,848 @@
+- !!map
+  id:                 0
+  name:               Sun
+  radius:             261600000
+  atmosphereAlt:      600000
+  mass:               1.7565459e+28
+  stdGravParam:       1172332800000000000
+  soi:                .inf
+  color:              0xffff00
+
+- !!map
+  id:                 1
+  name:               Moho
+  radius:             250000
+  mass:               2.5263314e+21
+  stdGravParam:       168609380000
+  soi:                9646663
+  orbit:
+    semiMajorAxis:    5263138304
+    eccentricity:     0.2
+    inclination:      7
+    argOfPeriapsis:   15
+    ascNodeLongitude: 70
+  meanAnomaly0:       3.14
+  epoch:              0
+  orbiting:           0
+  color:              0xa88161
+
+- !!map
+  id:                 2
+  name:               Eve
+  radius:             700000
+  atmosphereAlt:      90000
+  mass:               1.224398e+23
+  stdGravParam:       8171730200000
+  soi:                85109365
+  orbit:
+    semiMajorAxis:    9832684544
+    eccentricity:     0.01
+    inclination:      2.1
+    argOfPeriapsis:   0
+    ascNodeLongitude: 15
+  meanAnomaly0:       3.14
+  epoch:              0
+  orbiting:           0
+  color:              0x6c20e4
+
+- !!map
+  id:                 3
+  name:               Gilly
+  radius:             13000
+  mass:               124203630000000000
+  stdGravParam:       8289449.8
+  soi:                126123.27
+  orbit:
+    semiMajorAxis:    31500000
+    eccentricity:     0.55
+    inclination:      12
+    argOfPeriapsis:   10
+    ascNodeLongitude: 80
+  meanAnomaly0:       0.9
+  epoch:              0
+  orbiting:           2
+  color:              0x6f5248
+
+- !!map
+  id:                 4
+  name:               Kerbin
+  radius:             600000
+  atmosphereAlt:      70000
+  mass:               5.2915158e+22
+  stdGravParam:       3531600000000
+  soi:                84159286
+  orbit:
+    semiMajorAxis:    13599840256
+    eccentricity:     0
+    inclination:      0
+    argOfPeriapsis:   0
+    ascNodeLongitude: 0
+  meanAnomaly0:       3.14
+  epoch:              0
+  orbiting:           0
+  color:              0x8acac2
+
+- !!map
+  id:                 5
+  name:               Mun
+  radius:             200000
+  mass:               975990660000000000000
+  stdGravParam:       65138398000
+  soi:                2429559.1
+  orbit:
+    semiMajorAxis:    12000000
+    eccentricity:     0
+    inclination:      0
+    argOfPeriapsis:   0
+    ascNodeLongitude: 0
+  meanAnomaly0:       1.7
+  epoch:              0
+  orbiting:           4
+  color:              0x6b6a76
+
+- !!map
+  id:                 6
+  name:               Minmus
+  radius:             60000
+  mass:               26457580000000000000
+  stdGravParam:       1765800000
+  soi:                2247428.4
+  orbit:
+    semiMajorAxis:    47000000
+    eccentricity:     0
+    inclination:      6
+    argOfPeriapsis:   38
+    ascNodeLongitude: 78
+  meanAnomaly0:       0.9
+  epoch:              0
+  orbiting:           4
+  color:              0x5b4c68
+
+- !!map
+  id:                 7
+  name:               Duna
+  radius:             320000
+  atmosphereAlt:      50000
+  mass:               4.515427e+21
+  stdGravParam:       301363210000
+  soi:                47921949
+  orbit:
+    semiMajorAxis:    20726155264
+    eccentricity:     0.051
+    inclination:      0.06
+    argOfPeriapsis:   0
+    ascNodeLongitude: 135.5
+  meanAnomaly0:       3.14
+  epoch:              0
+  orbiting:           0
+  color:              0xa23e28
+
+- !!map
+  id:                 8
+  name:               Ike
+  radius:             130000
+  mass:               278216150000000000000
+  stdGravParam:       18568369000
+  soi:                1049598.9
+  orbit:
+    semiMajorAxis:    3200000
+    eccentricity:     0.03
+    inclination:      0.2
+    argOfPeriapsis:   0
+    ascNodeLongitude: 0
+  meanAnomaly0:       1.7
+  epoch:              0
+  orbiting:           7
+  color:              0x5d5d5f
+
+- !!map
+  id:                 9
+  name:               Edas
+  radius:             2000
+  mass:               15222104790015432
+  stdGravParam:       1015968.94
+  soi:                326421.802599829
+  orbit:
+    semiMajorAxis:    21809870000
+    eccentricity:     0.2226
+    inclination:      10.828
+    argOfPeriapsis:   7
+    ascNodeLongitude: 304.32
+  meanAnomaly0:       178.82
+  epoch:              1
+  orbiting:           0
+  color:              0x4f4d48
+
+- !!map
+  id:                 10
+  name:               Vant
+  radius:             69000
+  mass:               34277505833570562000
+  stdGravParam:       2287783571.85
+  soi:                11595956.61565824
+  orbit:
+    semiMajorAxis:    35331876000
+    eccentricity:     0.08874
+    inclination:      7.14043
+    argOfPeriapsis:   151.19853
+    ascNodeLongitude: 103.85136
+  meanAnomaly0:       20.86384
+  epoch:              1
+  orbiting:           0
+  color:              0x9a9684
+
+- !!map
+  id:                 11
+  name:               Dres
+  radius:             138000
+  mass:               321909370000000000000
+  stdGravParam:       21484489000
+  soi:                32832840
+  orbit:
+    semiMajorAxis:    40839348203
+    eccentricity:     0.145
+    inclination:      5
+    argOfPeriapsis:   90
+    ascNodeLongitude: 280
+  meanAnomaly0:       3.14
+  epoch:              0
+  orbiting:           0
+  color:              0x5a4432
+
+- !!map
+  id:                 12
+  name:               Zore
+  radius:             34500
+  mass:               8569376458392641000
+  stdGravParam:       571945892.9625
+  soi:                8236046.817973213
+  orbit:
+    semiMajorAxis:    43692100000
+    eccentricity:     0.14
+    inclination:      3.095
+    argOfPeriapsis:   228.047
+    ascNodeLongitude: 150.352
+  meanAnomaly0:       323.379
+  epoch:              1
+  orbiting:           0
+  color:              0xc39176
+
+- !!map
+  id:                 13
+  name:               LintMikey
+  radius:             550
+  mass:               6667017421302.607
+  stdGravParam:       444.9767437499999
+  soi:                35163.24090915114
+  orbit:
+    semiMajorAxis:    51806000000
+    eccentricity:     0.64102
+    inclination:      7.0405
+    argOfPeriapsis:   12.78
+    ascNodeLongitude: 122.11
+  meanAnomaly0:       303.71
+  epoch:              1
+  orbiting:           0
+  color:              0x3c3c3c
+
+- !!map
+  id:                 14
+  name:               Jool
+  radius:             6000000
+  atmosphereAlt:      200000
+  mass:               4.2332127e+24
+  stdGravParam:       282528000000000
+  soi:                2455985200
+  orbit:
+    semiMajorAxis:    68773560320
+    eccentricity:     0.05
+    inclination:      1.304
+    argOfPeriapsis:   0
+    ascNodeLongitude: 52
+  meanAnomaly0:       0.1
+  epoch:              0
+  orbiting:           0
+  color:              0x548412
+
+- !!map
+  id:                 15
+  name:               Laythe
+  radius:             500000
+  atmosphereAlt:      50000
+  mass:               2.9397311e+22
+  stdGravParam:       1962000000000
+  soi:                3723645.8
+  orbit:
+    semiMajorAxis:    27184000
+    eccentricity:     0
+    inclination:      0
+    argOfPeriapsis:   0
+    ascNodeLongitude: 0
+  meanAnomaly0:       3.14
+  epoch:              0
+  orbiting:           14
+  color:              0x2c306a
+
+- !!map
+  id:                 16
+  name:               Vall
+  radius:             300000
+  mass:               3.1087655e+21
+  stdGravParam:       207481500000
+  soi:                2406401.4
+  orbit:
+    semiMajorAxis:    43152000
+    eccentricity:     0
+    inclination:      0
+    argOfPeriapsis:   0
+    ascNodeLongitude: 0
+  meanAnomaly0:       0.9
+  epoch:              0
+  orbiting:           14
+  color:              0x476c7c
+
+- !!map
+  id:                 17
+  name:               Tylo
+  radius:             600000
+  mass:               4.2332127e+22
+  stdGravParam:       2825280000000
+  soi:                10856518
+  orbit:
+    semiMajorAxis:    68500000
+    eccentricity:     0
+    inclination:      0.025
+    argOfPeriapsis:   0
+    ascNodeLongitude: 0
+  meanAnomaly0:       3.14
+  epoch:              0
+  orbiting:           14
+  color:              0x937575
+
+- !!map
+  id:                 18
+  name:               Bop
+  radius:             65000
+  mass:               37261090000000000000
+  stdGravParam:       2486834900
+  soi:                1221060.9
+  orbit:
+    semiMajorAxis:    128500000
+    eccentricity:     0.235
+    inclination:      15
+    argOfPeriapsis:   25
+    ascNodeLongitude: 14
+  meanAnomaly0:       0.9
+  epoch:              0
+  orbiting:           10
+  color:              0x7f6d51
+
+- !!map
+  id:                 19
+  name:               Pol
+  radius:             44000
+  mass:               10813507000000000000
+  stdGravParam:       721702080
+  soi:                1042138.9
+  orbit:
+    semiMajorAxis:    179890000
+    eccentricity:     0.171
+    inclination:      4.25
+    argOfPeriapsis:   15
+    ascNodeLongitude: 2
+  meanAnomaly0:       0.9
+  epoch:              0
+  orbiting:           14
+  color:              0x9ba078
+
+- !!map
+  id:                 20
+  name:               Crokslev
+  radius:             32500
+  mass:               3879910276171284000
+  stdGravParam:       258956851.56249997
+  soi:                9442486.655069731
+  orbit:
+    semiMajorAxis:    68773560320
+    eccentricity:     0.03
+    inclination:      11.5
+    argOfPeriapsis:   242.9
+    ascNodeLongitude: 300.43
+  meanAnomaly0:       5.335987757478592
+  epoch:              1
+  orbiting:           0
+  color:              0x644643
+
+- !!map
+  id:                 21
+  name:               Sarnus
+  radius:             5300000
+  atmosphereAlt:      580000.0
+  mass:               1.229937251142442e+24
+  stdGravParam:       82089701953000
+  soi:                2740090587.726858
+  orbit:
+    semiMajorAxis:    125798522368
+    eccentricity:     0.0534
+    inclination:      2.02
+    argOfPeriapsis:   0
+    ascNodeLongitude: 184
+  meanAnomaly0:       2.88114666938782
+  epoch:              359.279999999964
+  orbiting:           0
+  color:              0xddb887
+
+- !!map
+  id:                 22
+  name:               Hale
+  radius:             6000
+  mass:               12165929310938976
+  stdGravParam:       811990.62
+  soi:                41000
+  orbit:
+    semiMajorAxis:    10488231
+    eccentricity:     0
+    inclination:      1
+    argOfPeriapsis:   0
+    ascNodeLongitude: 55
+  meanAnomaly0:       0
+  epoch:              0
+  orbiting:           21
+  color:              0xefe68c
+
+- !!map
+  id:                 23
+  name:               Ovok
+  radius:             26000
+  mass:               198651406139969730
+  stdGravParam:       13258590.799999999
+  soi:                94000
+  orbit:
+    semiMajorAxis:    12169413
+    eccentricity:     0.01
+    inclination:      1.5
+    argOfPeriapsis:   0
+    ascNodeLongitude: 55
+  meanAnomaly0:       1.72
+  epoch:              751.7
+  orbiting:           21
+  color:              0xafc3dd
+
+- !!map
+  id:                 24
+  name:               Eeloo
+  radius:             210000
+  mass:               1.1149224e+21
+  stdGravParam:       74410815000
+  soi:                1159081.4292819728
+  orbit:
+    semiMajorAxis:    19105978
+    eccentricity:     0.0034
+    inclination:      2.3
+    argOfPeriapsis:   260
+    ascNodeLongitude: 55
+  meanAnomaly0:       3.14
+  epoch:              0
+  orbiting:           21
+  color:              0x686a6a
+
+- !!map
+  id:                 25
+  name:               Slate
+  radius:             540000
+  mass:               2.9648898684206585e+22
+  stdGravParam:       1978856444880
+  soi:                9598158.646011835
+  orbit:
+    semiMajorAxis:    42592946
+    eccentricity:     0.04
+    inclination:      2.3
+    argOfPeriapsis:   0
+    ascNodeLongitude: 55
+  meanAnomaly0:       1.1
+  epoch:              1343.91
+  orbiting:           21
+  color:              0xd1b38c
+
+- !!map
+  id:                 26
+  name:               Tekto
+  radius:             280000
+  atmosphereAlt:      95000.0
+  mass:               2.883313492171464e+21
+  stdGravParam:       192440992408
+  soi:                8637005.195444612
+  orbit:
+    semiMajorAxis:    97355304
+    eccentricity:     0.028
+    inclination:      9.4
+    argOfPeriapsis:   0
+    ascNodeLongitude: 55
+  meanAnomaly0:       2.1
+  epoch:              1275.12
+  orbiting:           21
+  color:              0x4ce5a5
+
+- !!map
+  id:                 27
+  name:               Havous
+  radius:             116666
+  mass:               285982596742195800000
+  stdGravParam:       19087336454.364372
+  soi:                83412861.25741543
+  orbit:
+    semiMajorAxis:    108782986529
+    eccentricity:     0.19
+    inclination:      13.21
+    argOfPeriapsis:   237.56
+    ascNodeLongitude: 122.11
+  meanAnomaly0:       226.6
+  epoch:              6
+  orbiting:           0
+  color:              0xcae8e3
+
+- !!map
+  id:                 28
+  name:               Kal
+  radius:             3000
+  mass:               1124026077641100.8
+  stdGravParam:       75020.87249999998
+  soi:                20000
+  orbit:
+    semiMajorAxis:    406750
+    eccentricity:     0.001
+    inclination:      0.02
+    argOfPeriapsis:   34
+    ascNodeLongitude: 245
+  meanAnomaly0:       12
+  epoch:              6
+  orbiting:           27
+  color:              0x333333
+
+- !!map
+  id:                 29
+  name:               KiKi
+  radius:             5320
+  mass:               6653623144539503
+  stdGravParam:       444082.76953600004
+  soi:                49438.1388104505
+  orbit:
+    semiMajorAxis:    3526750
+    eccentricity:     0.11
+    inclination:      11.45
+    argOfPeriapsis:   123
+    ascNodeLongitude: 256
+  meanAnomaly0:       85
+  epoch:              6
+  orbiting:           27
+  color:              0x544040
+
+- !!map
+  id:                 30
+  name:               Urlum
+  radius:             2177000
+  atmosphereAlt:      325000.0
+  mass:               1.7896369311579417e+23
+  stdGravParam:       11944573769627.45
+  soi:                2562226897.2821903
+  orbit:
+    semiMajorAxis:    254317012787
+    eccentricity:     0.045214674
+    inclination:      0.64
+    argOfPeriapsis:   0
+    ascNodeLongitude: 61
+  meanAnomaly0:       5.59607362747192
+  epoch:              422.539999999906
+  orbiting:           0
+  color:              0x48d1cc
+
+- !!map
+  id:                 31
+  name:               Polta
+  radius:             220000
+  mass:               1.3511821973839953e+21
+  stdGravParam:       90181953400
+  soi:                1661114.8530520673
+  orbit:
+    semiMajorAxis:    11727895
+    eccentricity:     0.0015
+    inclination:      2.45
+    argOfPeriapsis:   60
+    ascNodeLongitude: 40
+  meanAnomaly0:       1.5209
+  epoch:              878.1399
+  orbiting:           30
+  color:              0x7a9f93
+
+- !!map
+  id:                 32
+  name:               Priax
+  radius:             74000
+  mass:               50689608950751390000
+  stdGravParam:       3383176570.2
+  soi:                446767.6019786148
+  orbit:
+    semiMajorAxis:    11727895
+    eccentricity:     0.0015
+    inclination:      2.5
+    argOfPeriapsis:   0
+    ascNodeLongitude: 40
+  meanAnomaly0:       1.5209
+  epoch:              878.1399
+  orbiting:           30
+  color:              0x6b6a66
+
+- !!map
+  id:                 33
+  name:               Wal
+  radius:             370000
+  mass:               7.44252194911826e+21
+  stdGravParam:       496736242450
+  soi:                18933504.68477647
+  orbit:
+    semiMajorAxis:    67553668
+    eccentricity:     0.023
+    inclination:      1.9
+    argOfPeriapsis:   0
+    ascNodeLongitude: 40
+  meanAnomaly0:       2.9615
+  epoch:              1078.179
+  orbiting:           30
+  color:              0xb89963
+
+- !!map
+  id:                 34
+  name:               Tal
+  radius:             22000
+  mass:               3200168362225252400
+  stdGravParam:       213588837
+  soi:                139966.65125981288
+  orbit:
+    semiMajorAxis:    3109163
+    eccentricity:     0
+    inclination:      1.9
+    argOfPeriapsis:   0
+    ascNodeLongitude: 40
+  meanAnomaly0:       0
+  epoch:              1179.579
+  orbiting:           33
+  color:              0x665b4a
+
+- !!map
+  id:                 35
+  name:               Mracksis
+  radius:             71500
+  mass:               90889226165478030000
+  stdGravParam:       6066219621.9625
+  soi:                55351388.17264619
+  orbit:
+    semiMajorAxis:    114179294679
+    eccentricity:     0.16126
+    inclination:      7.5
+    argOfPeriapsis:   294.834
+    ascNodeLongitude: 122.11
+  meanAnomaly0:       165.514
+  epoch:              6
+  orbiting:           0
+  color:              0xbc495
+
+- !!map
+  id:                 36
+  name:               Flake
+  radius:             2000
+  mass:               176317816100564.88
+  stdGravParam:       11767.98
+  soi:                20000
+  orbit:
+    semiMajorAxis:    659162
+    eccentricity:     0.05
+    inclination:      5
+    argOfPeriapsis:   213
+    ascNodeLongitude: 12
+  meanAnomaly0:       45
+  epoch:              6
+  orbiting:           35
+  color:              0xb2cbce
+
+- !!map
+  id:                 37
+  name:               Geito
+  radius:             1000
+  mass:               44079454025141.22
+  stdGravParam:       2941.995
+  soi:                221638.83004387212
+  orbit:
+    semiMajorAxis:    153396400000
+    eccentricity:     0.96714
+    inclination:      102.26
+    argOfPeriapsis:   161.33
+    ascNodeLongitude: 58.42
+  meanAnomaly0:       218.38
+  epoch:              1
+  orbiting:           0
+  color:              0x3c3c3c
+
+- !!map
+  id:                 38
+  name:               Neidon
+  radius:             2145000
+  atmosphereAlt:      260000.0
+  mass:               2.1227516788730655e+23
+  stdGravParam:       14167881530302.5
+  soi:                4415665622.289967
+  orbit:
+    semiMajorAxis:    409355191706
+    eccentricity:     0.0127567
+    inclination:      1.27
+    argOfPeriapsis:   0
+    ascNodeLongitude: 259
+  meanAnomaly0:       2.27167344093323
+  epoch:              99.6799999999973
+  orbiting:           0
+  color:              0x6959cd
+
+- !!map
+  id:                 39
+  name:               Thatmo
+  radius:             286000
+  atmosphereAlt:      35000.0
+  mass:               2.7882711365806153e+21
+  stdGravParam:       186097580468.8
+  soi:                5709379.088531882
+  orbit:
+    semiMajorAxis:    32300895
+    eccentricity:     0.00043
+    inclination:      161.1
+    argOfPeriapsis:   0
+    ascNodeLongitude: 66
+  meanAnomaly0:       2.04731106758118
+  epoch:              1953406.32967385
+  orbiting:           38
+  color:              0xe6e6f9
+
+- !!map
+  id:                 40
+  name:               Nissee
+  radius:             30000
+  mass:               5950726293394064000
+  stdGravParam:       397169325
+  soi:                7366476.635255131
+  orbit:
+    semiMajorAxis:    487743514
+    eccentricity:     0.72
+    inclination:      29.56
+    argOfPeriapsis:   0
+    ascNodeLongitude: 66
+  meanAnomaly0:       2.04731106758118
+  epoch:              1953406.32967385
+  orbiting:           38
+  color:              0xd1b38c
+
+- !!map
+  id:                 41
+  name:               Ervo
+  radius:             192000
+  atmosphereAlt:      44000
+  mass:               877470296318715100000
+  stdGravParam:       58564999987.2
+  soi:                204419679.1476721
+  orbit:
+    semiMajorAxis:    170252514114
+    eccentricity:     0.4
+    inclination:      10.5
+    argOfPeriapsis:   151.7
+    ascNodeLongitude: 35.9
+  meanAnomaly0:       205
+  epoch:              6
+  orbiting:           0
+  color:              0x77726d
+
+- !!map
+  id:                 42
+  name:               Archae
+  radius:             55000
+  mass:               26668069685210436000
+  stdGravParam:       1779906975
+  soi:                367385.88985377084
+  orbit:
+    semiMajorAxis:    1486000
+    eccentricity:     0.03
+    inclination:      1.2
+    argOfPeriapsis:   30
+    ascNodeLongitude: 130
+  meanAnomaly0:       25
+  epoch:              6
+  orbiting:           41
+  color:              0x353335
+
+- !!map
+  id:                 43
+  name:               Plock
+  radius:             189000
+  mass:               776784007434487600000
+  stdGravParam:       51844895008.2
+  soi:                612754258.4676156
+  orbit:
+    semiMajorAxis:    535833706086
+    eccentricity:     0.26
+    inclination:      6.15
+    argOfPeriapsis:   50
+    ascNodeLongitude: 260
+  meanAnomaly0:       0
+  epoch:              213
+  orbiting:           0
+  color:              0xNaN
+
+- !!map
+  id:                 44
+  name:               Karen
+  radius:             85050
+  mass:               70146744995688686000
+  stdGravParam:       4681804201.24725
+  soi:                939354.3242775212
+  orbit:
+    semiMajorAxis:    2457800
+    eccentricity:     0
+    inclination:      0
+    argOfPeriapsis:   50
+    ascNodeLongitude: 260
+  meanAnomaly0:       0
+  epoch:              213
+  orbiting:           43
+  color:              0xNaN
+
+- !!map
+  id:                 45
+  name:               Soden
+  radius:             61000
+  mass:               54673216142516820000
+  stdGravParam:       3649054465
+  soi:                478519616.2606986
+  orbit:
+    semiMajorAxis:    1209633200000
+    eccentricity:     0.84123
+    inclination:      11.929
+    argOfPeriapsis:   311.53
+    ascNodeLongitude: 144.32
+  meanAnomaly0:       358.04
+  epoch:              6
+  orbiting:           0
+  color:              0xe9e0eb
+
+- !!map
+  id:                 46
+  name:               Lon
+  radius:             5000
+  mass:               7346575670856870
+  stdGravParam:       490332.5
+  soi:                41357.43701358759
+  orbit:
+    semiMajorAxis:    1462950
+    eccentricity:     0.2
+    inclination:      9.8
+    argOfPeriapsis:   7
+    ascNodeLongitude: 124
+  meanAnomaly0:       123
+  epoch:              6
+  orbiting:           45
+  color:              0xcfc9a8

--- a/data/mpe-opm/config.yml
+++ b/data/mpe-opm/config.yml
@@ -1,0 +1,72 @@
+# Configuration file for the application
+
+rendering:
+  scale:              1.0e-9        # scale of the objects compared to real values
+  fov:                75            # field of view of the camera
+  nearPlane:          0.0000001     # near plane distance
+  farPlane:           1000          # far plane distance
+
+solarSystem:
+  planetFarSize:      0.05          # size of planet sprites
+  satFarSize:         0.04          # size of satellites sprites
+  satDispRadii:       10            # minimum display distance of satellites (in radii of the scaled semi major axis)
+  spriteDispSOIMul:   18            # minimum display distance of sprites (in multiple of the SOI of the body to which they are attached)
+  mouseFocusDst:      25            # minimum distance to between body on screen and mouse to set focus (in pixels)
+  soiOpacity:         0.3           # the opacity of SOI spheres
+
+orbit:
+  satSampPoints:      1000          # sample points for satellites' orbits
+  planetSampPoints:   10000         # sample points for planets' orbits
+  orbitLineWidth:     1.5           # width of the rendered orbit lines
+  arcLineWidth:       2.25          # width of the rendered trajectory arc lines
+  epochOffset:        0             # offset for bodies' epochs (reference for epoch 0), in seconds
+
+camera:
+  startDist:          100           # distance from sun of start
+  maxDist:            1000           # maximum distance that can be zoomed out
+  minDistRadii:       1.5           # minimum distance to a body, in radii of the focused body
+  dampingFactor:      0.5           # camera motion damping
+  rotateSpeed:        0.5           # camera rotation speed
+
+time:
+  type:               base          # type of the time system: either base or real
+  hoursPerDay:        6             # number of hours in a day (Kerbal day) (base only)
+  daysPerYear:        426           # number of days per year (Kerbal year) (base only)
+
+flybySequence:
+  radiusSamples:      10            # number of samples radius samples to test when evaluating a sequence feasability
+  initVelMaxScale:    3             # upper bound of ejection velocity range, as factor of direct hohmann transfert to the next body
+  initVelSamples:     20            # number of samples for start body ejection between direct hohmann transfert and initVelMaxScale
+  maxPropositions:    15            # maximum number of sequences propositions after sequence generation
+  maxEvalStatuses:    100000        # maximum number status considered when evaluating a sequence before timeout
+  maxEvalSequences:   100000        # maximum number of sequences to evaluate
+  splitLimit:         2500          # maximum input chunk size per worker in the worker pool, exceeded if all workers are already used
+
+trajectorySearch:
+  splitLimit:         1000          # maximum input chunk size per worker in the worker pool, exceeded if all workers are already used
+  minCrossProba:      0.9           # The minimum crossover probability (CR) of the DE algorithm
+  maxCrossProba:      0.99          # The maximum crossover probability (CR) of the DE algorithm
+  crossProbaIncr:     8             # The exponential speed factor by which CR increases from its minium to maximum
+  diffWeight:         0.3           # differential weight (F) of the DE algorithm
+  depDVScaleMin:      1.01          # the minimum ejection velocity, in terms of scale of the minimum velocity required to escape the body
+  depDVScaleMax:      3             # the maximum ejection velocity
+  dsmOffsetMin:       0.01          # the minimum offset of a DSM on an interplanetary leg
+  dsmOffsetMax:       0.99          # the maximum offset of a DSM
+  minLegDuration:     21600         # the minimum duration of a leg (s)
+  fbRadiusMaxScale:   4             # the maximum periapsis height of a flyby orbit, in terms of times radius of the body
+  popSizeDimScale:    750           # the population size is equal to this value times the dimension of the search space (number of compnents agent vector)
+  maxGenerations:     300           # Maximum number of evolution iterations
+
+editor:
+  defaultOrigin:      3             # default origin body on start (index of Kerbin in the selector)
+  defaultDest:        0             # default destination body on start (index of Moho in the selector)
+  defaultAltitude:    100           # default altitude from the default body (in km above surface)
+  defaultMaxDuration: 500           # default duration limit for a trajectory (in number of days)
+
+workers:
+  progressStep:       250           # number of inputs processed per chunk before progress callback
+
+trajectoryDraw:
+  samplePoints:       2500          # number sample points for each tarjectory arc draw
+  spritesSize:        0.08          # size of the sprites for maneuvers, encounters, escapes
+  podSpriteSize:      0.06          # size of the pod sprite

--- a/data/systems.yml
+++ b/data/systems.yml
@@ -21,6 +21,9 @@
 - name: KSRSS Reborn
   folderName: ksrss
 
+- name: OPM + Minor Planets Expansion
+  folderName: mpe-opm
+
 # Template:
 # - name: New Solar System
 #   folderName: new-solar-system


### PR DESCRIPTION
Add a planet config for the Minor Planets Expansion & Outer Planets mod together. 

https://forum.kerbalspaceprogram.com/topic/192848-112x-planet-pack-minor-planets-expansion/

https://forum.kerbalspaceprogram.com/topic/184789-131-112x-outer-planets-mod-v2212-23rd-dec-2025/

incl. 31 stock/OPM bodies plus 15 MPE bodies, for a total of 46 planets/dwarf planets/asteroids/moons.